### PR TITLE
[feat] Pin 생성 API 구현 

### DIFF
--- a/src/main/java/com/sopkathon/teamweb/domain/pin/controller/PinController.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/controller/PinController.java
@@ -1,10 +1,15 @@
 package com.sopkathon.teamweb.domain.pin.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateRequest;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateResponse;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinGetResponse;
 import com.sopkathon.teamweb.domain.pin.service.PinService;
 import com.sopkathon.teamweb.global.common.dto.ResponseDto;
@@ -22,5 +27,13 @@ public class PinController {
 		PinGetResponse response = pinService.getPinDetail(pinId);
 
 		return ResponseDto.ok(response);
+	}
+
+	@PostMapping
+	public ResponseDto<PinCreateResponse> createPin(@RequestBody PinCreateRequest createRequest) {
+
+		PinCreateResponse response = pinService.createPin(createRequest);
+
+		return ResponseDto.created(response);
 	}
 }

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/domain/Pin.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/domain/Pin.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.sopkathon.teamweb.domain.pin.domain.constant.DefaultMark;
 import com.sopkathon.teamweb.domain.pin.domain.constant.Region;
 import com.sopkathon.teamweb.domain.pin.domain.constant.Review;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateRequest;
 import com.sopkathon.teamweb.domain.user.domain.User;
 import com.sopkathon.teamweb.global.common.entity.BaseEntity;
 
@@ -21,6 +22,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,7 +37,7 @@ public class Pin extends BaseEntity {
 
 	private String placeName;
 
-	private String oneliner;
+	private String oneliner; // 한 줄 평가
 
 	private Double latitude;
 
@@ -78,4 +80,46 @@ public class Pin extends BaseEntity {
 
 		return total > 0 ? Math.round((double)hates / total * 100) : 0;
 	}
+
+	@Builder
+	public Pin(String placeName, String oneliner, Double latitude, Double longitude, String image, long likeCount,
+		long hateCount, DefaultMark defaultMark, User author, List<Review> reviews, Region region) {
+		this.placeName = placeName;
+		this.oneliner = oneliner;
+		this.latitude = latitude;
+		this.longitude = longitude;
+		this.image = image;
+		this.likeCount = likeCount;
+		this.hateCount = hateCount;
+		this.defaultMark = defaultMark;
+		this.author = author;
+		this.reviews = reviews;
+		this.region = region;
+	}
+
+	public static Pin makePin(boolean isCorrect, String placeName, String oneliner, double latitude,
+		double longitude, String image, List<Review> reviews, Region region) {
+
+		//isCorrect 가 1 이면 DefaultMark 를 O로 설정
+		DefaultMark mark = isCorrect ? DefaultMark.O : DefaultMark.X;
+
+		long likeCount = isCorrect ? 1L : 0L;
+		long hateCount = isCorrect ? 0L : 1L;
+
+		return Pin.builder()
+			.placeName(placeName)
+			.oneliner(oneliner)
+			.latitude(latitude)
+			.longitude(longitude)
+			.image(image)
+			.likeCount(likeCount) // 기본값
+			.hateCount(hateCount) // 기본값
+			.defaultMark(mark) // enum 기본값 또는 null 가능
+			.reviews(reviews)
+			.region(region)
+			.build();
+	}
+
+
 }
+

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateRequest.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateRequest.java
@@ -1,0 +1,20 @@
+package com.sopkathon.teamweb.domain.pin.dto.response;
+
+import java.util.List;
+
+import com.sopkathon.teamweb.domain.pin.domain.constant.Region;
+import com.sopkathon.teamweb.domain.pin.domain.constant.Review;
+
+public record PinCreateRequest(
+	boolean isCorrect,
+	String image,
+	Region region,
+	String placeName,
+	double latitude,
+	double longitude,
+	List<Review> reviews, // 평가칩 여러개
+	String oneliner
+) {
+
+
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateResponse.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateResponse.java
@@ -1,0 +1,33 @@
+package com.sopkathon.teamweb.domain.pin.dto.response;
+
+import java.util.List;
+
+import com.sopkathon.teamweb.domain.pin.domain.Pin;
+import com.sopkathon.teamweb.domain.pin.domain.constant.Review;
+
+public record PinCreateResponse(
+	long pinId,
+	double latitude,
+	double longitude,
+	String image,
+	String oneLiner,
+	List<Review> reviews,
+	long likeRate,
+	long hateLate
+) {
+
+	public static PinCreateResponse from(Pin pin) {
+		return new PinCreateResponse(
+			pin.getId(),
+			pin.getLatitude(),
+			pin.getLongitude(),
+			pin.getImage(),
+			pin.getOneliner(),
+			pin.getReviews(),
+			pin.getLikeRate(),
+			pin.getHateRate()
+		);
+	}
+
+
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/service/PinService.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/service/PinService.java
@@ -3,6 +3,8 @@ package com.sopkathon.teamweb.domain.pin.service;
 import org.springframework.stereotype.Service;
 
 import com.sopkathon.teamweb.domain.pin.domain.Pin;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateRequest;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateResponse;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinGetResponse;
 import com.sopkathon.teamweb.domain.pin.repository.PinRepository;
 
@@ -17,5 +19,15 @@ public class PinService {
 		Pin pin = pinRepository.findById(pinId).get();
 
 		return PinGetResponse.from(pin);
+	}
+
+	public PinCreateResponse createPin(PinCreateRequest req) {
+		Pin pin = Pin.makePin(req.isCorrect(), req.placeName(),req.oneliner(),
+			req.latitude(), req.longitude(), req.image(), req.reviews(),
+			req.region());
+
+		pinRepository.save(pin);
+
+		return PinCreateResponse.from(pin);
 	}
 }


### PR DESCRIPTION
## 🚀 PR 요약
핀 생성 POST API 를 구현하였습니다.

## ✨ PR 상세 내용
클라이언트로부터, 아니여유 맞아유  여부, 장소이름, 한줄 내용, 위도, 경도, 이미지, 평가칩, 지역 이름을 받아서 
Pin 을 생성합니다.
Pin 생성과 동시에, 아니여유 맞아유 boolean 값에 따라 likeCount 또는 hateCount 를 증가 시킵니다.
또한, defaultmark 또한 설정합니다.

## 🚨 주의 사항


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
