### PR TITLE
[feat] 투표 로직 구현 및 API 수정 

### DIFF
--- a/src/main/java/com/sopkathon/teamweb/domain/image/ImageController.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/image/ImageController.java
@@ -1,0 +1,26 @@
+package com.sopkathon.teamweb.domain.image;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.sopkathon.teamweb.global.common.dto.ResponseDto;
+import com.sopkathon.teamweb.infra.S3Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+	private final S3Service s3Service;
+
+	@PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseDto<String> upload(@RequestPart MultipartFile image){
+		String imageUrl = s3Service.upload(image, "images");
+		return ResponseDto.ok(imageUrl);
+	}
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/controller/PinController.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/controller/PinController.java
@@ -1,19 +1,28 @@
 package com.sopkathon.teamweb.domain.pin.controller;
 
+import static org.springframework.http.MediaType.*;
+
 import java.util.List;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.sopkathon.teamweb.domain.pin.dto.response.PinAllGetResponse;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateRequest;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateResponse;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinGetResponse;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinSimpleResponse;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinVoteRequest;
 import com.sopkathon.teamweb.domain.pin.service.PinService;
 import com.sopkathon.teamweb.global.common.dto.ResponseDto;
 
@@ -46,12 +55,23 @@ public class PinController {
 		return ResponseDto.ok(responses);
 	}
 
-
 	@PostMapping
-	public ResponseDto<PinCreateResponse> createPin(@RequestBody PinCreateRequest createRequest) {
+	public ResponseDto<PinCreateResponse> createPin(
+		@RequestHeader Long userId,
+		@RequestBody PinCreateRequest createRequest) {
 
-		PinCreateResponse response = pinService.createPin(createRequest);
+		PinCreateResponse response = pinService.createPin(createRequest, userId);
 
 		return ResponseDto.created(response);
 	}
+
+	@PatchMapping("/{userId}/{pinId}")
+	public ResponseDto<PinSimpleResponse> votePin(@PathVariable("userId") Long userId,
+		@PathVariable("pinId") Long pinId, @RequestBody PinVoteRequest pinVoteRequest) {
+
+		PinSimpleResponse response = pinService.votePin(userId, pinId, pinVoteRequest);
+		return ResponseDto.ok(response);
+	}
+
+
 }

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/domain/Pin.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/domain/Pin.java
@@ -81,6 +81,15 @@ public class Pin extends BaseEntity {
 		return total > 0 ? Math.round((double)hates / total * 100) : 0;
 	}
 
+	public void increaseLikeCount() {
+		this.likeCount += 1;
+	}
+
+	public void increaseHateCount() {
+		this.hateCount += 1;
+
+	}
+
 	@Builder
 	public Pin(String placeName, String oneliner, Double latitude, Double longitude, String image, long likeCount,
 		long hateCount, DefaultMark defaultMark, User author, List<Review> reviews, Region region) {
@@ -98,7 +107,7 @@ public class Pin extends BaseEntity {
 	}
 
 	public static Pin makePin(boolean isCorrect, String placeName, String oneliner, double latitude,
-		double longitude, String image, List<Review> reviews, Region region) {
+		double longitude, String image, List<Review> reviews, Region region, User user) {
 
 		//isCorrect 가 1 이면 DefaultMark 를 O로 설정
 		DefaultMark mark = isCorrect ? DefaultMark.O : DefaultMark.X;
@@ -117,6 +126,7 @@ public class Pin extends BaseEntity {
 			.defaultMark(mark) // enum 기본값 또는 null 가능
 			.reviews(reviews)
 			.region(region)
+			.author(user)
 			.build();
 	}
 

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/domain/constant/Region.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/domain/constant/Region.java
@@ -3,7 +3,7 @@ package com.sopkathon.teamweb.domain.pin.domain.constant;
 import java.util.Arrays;
 
 public enum Region {
-	청주, 충주;
+	청주시, 충주시;
 
 	// String으로부터 Region을 찾는 정적 메서드
 	public static Region fromString(String value) {

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateRequest.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinCreateRequest.java
@@ -2,14 +2,16 @@ package com.sopkathon.teamweb.domain.pin.dto.response;
 
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.sopkathon.teamweb.domain.pin.domain.constant.Region;
 import com.sopkathon.teamweb.domain.pin.domain.constant.Review;
 
 public record PinCreateRequest(
-	boolean isCorrect,
-	String image,
+	boolean isLike,
 	Region region,
 	String placeName,
+	String imageUrl,
 	double latitude,
 	double longitude,
 	List<Review> reviews, // 평가칩 여러개

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinSimpleResponse.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinSimpleResponse.java
@@ -1,0 +1,25 @@
+package com.sopkathon.teamweb.domain.pin.dto.response;
+
+import java.util.List;
+
+import com.sopkathon.teamweb.domain.pin.domain.Pin;
+import com.sopkathon.teamweb.domain.pin.domain.constant.Review;
+
+public record PinSimpleResponse(
+	long pinId,
+	String image,
+	List<Review> reviews,
+	long likeRate,
+	long hateLate
+) {
+
+	public static PinSimpleResponse from(Pin pin) {
+		return new PinSimpleResponse(
+			pin.getId(),
+			pin.getImage(),
+			pin.getReviews(),
+			pin.getLikeRate(),
+			pin.getHateRate()
+		);
+	}
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinVoteRequest.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/dto/response/PinVoteRequest.java
@@ -1,0 +1,6 @@
+package com.sopkathon.teamweb.domain.pin.dto.response;
+
+public record PinVoteRequest(
+	boolean isLike
+) {
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/pin/service/PinService.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/pin/service/PinService.java
@@ -3,6 +3,8 @@ package com.sopkathon.teamweb.domain.pin.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.sopkathon.teamweb.domain.pin.domain.Pin;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateRequest;
@@ -10,8 +12,17 @@ import com.sopkathon.teamweb.domain.pin.dto.response.PinCreateResponse;
 import com.sopkathon.teamweb.domain.pin.domain.constant.Region;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinAllGetResponse;
 import com.sopkathon.teamweb.domain.pin.dto.response.PinGetResponse;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinSimpleResponse;
+import com.sopkathon.teamweb.domain.pin.dto.response.PinVoteRequest;
 import com.sopkathon.teamweb.domain.pin.excepiton.PinNotFoundException;
 import com.sopkathon.teamweb.domain.pin.repository.PinRepository;
+import com.sopkathon.teamweb.domain.user.domain.User;
+import com.sopkathon.teamweb.domain.user.exception.UserNotFoundException;
+import com.sopkathon.teamweb.domain.user.repository.UserRepository;
+import com.sopkathon.teamweb.domain.vote.AlreadyVotedException;
+import com.sopkathon.teamweb.domain.vote.domain.Vote;
+import com.sopkathon.teamweb.domain.vote.repository.VoteRepository;
+import com.sopkathon.teamweb.infra.S3Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,8 +30,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PinService {
 	private final PinRepository pinRepository;
+	private final VoteRepository voteRepository;
+	private final UserRepository userRepository;
+	private final S3Service s3Service;
 
 	public PinGetResponse getPinDetail(long pinId) {
 		Pin pin = pinRepository.findById(pinId).orElseThrow(PinNotFoundException::new);
@@ -44,13 +59,53 @@ public class PinService {
 			.toList();
 	}
 
-	public PinCreateResponse createPin(PinCreateRequest req) {
-		Pin pin = Pin.makePin(req.isCorrect(), req.placeName(),req.oneliner(),
-			req.latitude(), req.longitude(), req.image(), req.reviews(),
-			req.region());
+	@Transactional
+	public PinCreateResponse createPin(PinCreateRequest req, long userId) {
+		User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+		//해당  url을 pin에 넣기
+
+
+		Pin pin = Pin.makePin(req.isLike(), req.placeName(), req.oneliner(),
+			req.latitude(), req.longitude(), req.imageUrl(), req.reviews(),
+			req.region(),user);
 
 		pinRepository.save(pin);
 
 		return PinCreateResponse.from(pin);
+	}
+
+	@Transactional
+	public PinSimpleResponse votePin(Long userId, Long pinId, PinVoteRequest pinVoteRequest) {
+
+		User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+		Pin pin = pinRepository.findById(pinId).orElseThrow(PinNotFoundException::new);
+
+		// 해당 유저가 pin 에 이미 투표 했는지 확인
+		boolean voted = voteRepository.existsByUserAndPin(user, pin);
+
+		// 이미 투표했다면 ,예외 반환
+		if (voted) {
+			throw new AlreadyVotedException();
+		}
+
+		boolean isLike = pinVoteRequest.isLike();
+
+		Vote vote = Vote.builder()
+			.user(user)
+			.pin(pin)
+			.isLike(isLike)
+			.build();
+
+		if (isLike) {
+			pin.increaseLikeCount();
+		} else {
+			pin.increaseHateCount();
+		}
+
+		voteRepository.save(vote);
+
+		return PinSimpleResponse.from(pin);
+
 	}
 }

--- a/src/main/java/com/sopkathon/teamweb/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sopkathon.teamweb.domain.user.exception;
+
+import static com.sopkathon.teamweb.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopkathon.teamweb.global.common.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+	public UserNotFoundException() {
+		super(USER_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/vote/AlreadyVotedException.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/vote/AlreadyVotedException.java
@@ -1,0 +1,12 @@
+package com.sopkathon.teamweb.domain.vote;
+
+import static com.sopkathon.teamweb.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopkathon.teamweb.global.common.exception.BusinessException;
+import com.sopkathon.teamweb.global.common.exception.constant.ExceptionCode;
+
+public class AlreadyVotedException extends BusinessException {
+	public AlreadyVotedException(){
+		super(ALREADY_VOTED);
+	}
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/vote/domain/Vote.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/vote/domain/Vote.java
@@ -1,0 +1,52 @@
+package com.sopkathon.teamweb.domain.vote.domain;
+
+import com.sopkathon.teamweb.domain.pin.domain.Pin;
+import com.sopkathon.teamweb.domain.user.domain.User;
+import com.sopkathon.teamweb.global.common.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "votes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Vote extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne
+	@JoinColumn(name = "pin_id")
+	private Pin pin;
+
+	private boolean isLike; // true: 맞아유, false: 아니여유
+
+	@Builder
+	public Vote(User user, Pin pin, boolean isLike) {
+		this.user = user;
+		this.pin = pin;
+		this.isLike = isLike;
+	}
+
+	// 투표 변경 메서드
+	public void updateVote(boolean isLike) {
+		this.isLike = isLike;
+	}
+
+}

--- a/src/main/java/com/sopkathon/teamweb/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/sopkathon/teamweb/domain/vote/repository/VoteRepository.java
@@ -1,0 +1,15 @@
+package com.sopkathon.teamweb.domain.vote.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sopkathon.teamweb.domain.pin.domain.Pin;
+import com.sopkathon.teamweb.domain.user.domain.User;
+import com.sopkathon.teamweb.domain.vote.domain.Vote;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+	boolean existsByUserAndPin(User user, Pin pin);
+
+}

--- a/src/main/java/com/sopkathon/teamweb/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopkathon/teamweb/global/common/exception/constant/ExceptionCode.java
@@ -10,6 +10,8 @@ public enum ExceptionCode {
 	//400
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c4000", "잘못된 요청입니다."),
 	EMPTY_USER_ID(HttpStatus.BAD_REQUEST, "c40010", "유저ID는 필수입니다."),
+	ALREADY_VOTED(HttpStatus.BAD_REQUEST, "c40020", "이미 투표한 유저입니다."),
+
 
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),
@@ -23,7 +25,8 @@ public enum ExceptionCode {
 	DUPLICATE(HttpStatus.CONFLICT, "c4090", "이미 존재하는 리소스입니다."),
 
 	//500
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "c5000", "서버 내부 오류가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s5000", "서버 내부 오류가 발생했습니다."),
+	IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "s5001", "이미지 업로드 실패");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/sopkathon/teamweb/infra/S3Service.java
+++ b/src/main/java/com/sopkathon/teamweb/infra/S3Service.java
@@ -14,6 +14,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.sopkathon.teamweb.infra.exception.ImageUploadFailException;
+
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -44,11 +46,16 @@ public class S3Service {
 	}
 
 	// 단일 파일 업로드를 위한 메소드 추가
-	public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+	public String upload(MultipartFile multipartFile, String dirName)  {
 		List<MultipartFile> files = new ArrayList<>();
 		files.add(multipartFile);
-		List<String> urls = upload(files, dirName);
-		return urls.isEmpty() ? null : urls.get(0);
+		try{
+			List<String> urls = upload(files, dirName);
+			return urls.isEmpty() ? null : urls.get(0);
+		} catch (IOException e){
+			throw new ImageUploadFailException();
+
+		}
 	}
 
 	// 다중 파일 업로드

--- a/src/main/java/com/sopkathon/teamweb/infra/exception/ImageUploadFailException.java
+++ b/src/main/java/com/sopkathon/teamweb/infra/exception/ImageUploadFailException.java
@@ -1,0 +1,12 @@
+package com.sopkathon.teamweb.infra.exception;
+
+import static com.sopkathon.teamweb.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopkathon.teamweb.global.common.exception.BusinessException;
+import com.sopkathon.teamweb.global.common.exception.constant.ExceptionCode;
+
+public class ImageUploadFailException extends BusinessException {
+	public ImageUploadFailException() {
+		super(IMAGE_UPLOAD_FAIL);
+	}
+}


### PR DESCRIPTION
## 🚀 PR 요약
투표 로직을 구현 완료하였습니다.
기존에, 한 메소드 안에서 S3 업로드까지 같이 진행하던 방식에서,
API 를 따로 분리하여서 S3 에 이미지를 업로드하도록 변경했습니다.

PIN 을 만들때, 유저 id 를 전달하지 않았던 문제를 해결했습ㄴ디ㅏ.

## ✨ PR 상세 내용


## 🚨 주의 사항


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
